### PR TITLE
Nesting middleware context

### DIFF
--- a/pkg/fiber-otel/config.go
+++ b/pkg/fiber-otel/config.go
@@ -8,13 +8,15 @@ import (
 type Config struct {
 	Tracer                trace.Tracer
 	TracerStartAttributes []trace.SpanStartOption
-	SpanName              string
-	LocalKeyName          string
+	// SpanName is a template for span naming.
+	// The scope is fiber context.
+	SpanName     string
+	LocalKeyName string
 }
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	SpanName:     "http/request",
+	SpanName:     "{{ .Method }} {{ .Route.Path }}",
 	LocalKeyName: LocalsCtxKey,
 	TracerStartAttributes: []trace.SpanStartOption{
 		trace.WithSpanKind(trace.SpanKindServer),

--- a/pkg/fiber-otel/config.go
+++ b/pkg/fiber-otel/config.go
@@ -16,7 +16,7 @@ type Config struct {
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	SpanName:     "{{ .Method }} {{ .Route.Path }}",
+	SpanName:     "HTTP {{ .Method }}",
 	LocalKeyName: LocalsCtxKey,
 	TracerStartAttributes: []trace.SpanStartOption{
 		trace.WithSpanKind(trace.SpanKindServer),

--- a/pkg/fiber-otel/middleware.go
+++ b/pkg/fiber-otel/middleware.go
@@ -2,6 +2,7 @@ package fiber_otel
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"text/template"
 
@@ -50,8 +51,14 @@ func New(config ...Config) fiber.Handler {
 			return fmt.Errorf("cannot execute span name template: %w", err)
 		}
 
+		var ctx context.Context = c.Context()
+
+		if l, ok := c.Locals(LocalsCtxKey).(context.Context); ok {
+			ctx = l
+		}
+
 		otelCtx, span := Tracer.Start(
-			c.Context(),
+			ctx,
 			spanName.String(),
 			spanOptions...,
 		)


### PR DESCRIPTION
This PR contains a fix/implementation for nesting middleware contexts, so when this middleware is being invoked under the top-level middleware it would capture the context and won't duplicate a span