### PR TITLE
feat: 4xx http error no longer act as errors

### DIFF
--- a/pkg/fiber-otel/middleware.go
+++ b/pkg/fiber-otel/middleware.go
@@ -63,7 +63,7 @@ func New(config ...Config) fiber.Handler {
 
 		statusCode := c.Response().StatusCode()
 		attrs := semconv.HTTPAttributesFromHTTPStatusCode(statusCode)
-		spanStatus, spanMessage := semconv.SpanStatusFromHTTPStatusCode(statusCode)
+		spanStatus, spanMessage := semconv.SpanStatusFromHTTPStatusCodeAndSpanKind(statusCode, trace.SpanKindServer)
 		span.SetAttributes(attrs...)
 		span.SetStatus(spanStatus, spanMessage)
 


### PR DESCRIPTION
### Context
Usually HTTP errors code like 400 or 404 should not be treat as an error. This option has been added to opentelemetry specification in https://github.com/open-telemetry/opentelemetry-specification/pull/1998

### Changes
* [x] Use newly added function `SpanStatusFromHTTPStatusCodeAndSpanKind` as a way to get `spanStatus` and `spanMessage`