### PR TITLE
Deprecate fiber-opentelemetry package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Fiber OpenTelemetry
 
+## ❗️Important
+This repository is now **archived** because there is **new** official library available for everyone. Please migrate to https://github.com/gofiber/contrib/tree/main/otelfiber
+
+There is no need to keep two libraries to solve one problem. 
+
+## Old description
+
 OpenTelemetry trace middleware for [Fiber](https://github.com/gofiber/fiber) that adds traces to requests.
 
 ### Table of Contents


### PR DESCRIPTION
### Context
Since @lucasoares pointed out in #63 that there is now official package for fiber opentelementry. I don't thing we need `fiber-opentelemetry` package anymore.  Please migrate to https://github.com/gofiber/contrib/tree/main/otelfiber

### Changes
* [x] Update readme and archive this repository